### PR TITLE
Update tarball and add pkg-config to required packages.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 AST_VERSION=13
-AST_TARBALL=asterisk-13.2.0-rc1
+AST_TARBALL=asterisk-13.7.0
 PJPROJECT_TARBALL=pjproject-2.3
 CLEANUP=0
 
 install_prereqs() {
 	echo "*** Installing System Libraries ***"
 
-	PACKAGES="build-essential python-pip vim apache2 ssh ccache"
+	PACKAGES="build-essential python-pip vim apache2 ssh ccache pkg-config"
 	PACKAGES="${PACKAGES} libncurses-dev libssl-dev libxml2-dev libsqlite3-dev uuid-dev uuid"
 	PACKAGES="${PACKAGES} libspandsp-dev binutils-dev libsrtp-dev libedit-dev libjansson-dev"
 	PACKAGES="${PACKAGES} subversion git libxslt1-dev"


### PR DESCRIPTION
You had an old RC for 13.2 as the tarball and my ubuntu machine didn't have pkg-config installed, which caused configure to fail on asterisk, even though pjproject was present. Shouldn't hurt to update to latest stable Asterisk and require pkg-config in the apt stage.
